### PR TITLE
Tweak install.sh to restart splunk properly

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -254,8 +254,8 @@ fi
 
 
 
-# restart splunk web
-echo 'Restarting splunkweb...'
-$SPLUNK/bin/splunk restart splunkweb
+# restart Splunk
+echo 'Restarting Splunk...'
+$SPLUNK/bin/splunk restart
 
 echo "Done installing duo_splunk!"


### PR DESCRIPTION
restarting splunk fully instead of just splunkweb.

in theory - you should also change "SPLUNK" to "SPLUNK_HOME" because that's what Splunk uses as a naming convention in the environment vars.
