### PR TITLE
remove unused variables

### DIFF
--- a/duo_client_python/examples/splunk/splunk.py
+++ b/duo_client_python/examples/splunk/splunk.py
@@ -214,9 +214,6 @@ def admin_api_from_config(config_path):
 
 
 def main():
-    parser = optparse.OptionParser(usage="%prog [<config file path>]")
-    (options, args) = parser.parse_args(sys.argv[1:])
-
     if len(sys.argv) == 1:
         config_path = os.path.abspath(__file__)
         config_path = os.path.dirname(config_path)


### PR DESCRIPTION
In the example we do not use any argv so no point to try to get hold on the argv